### PR TITLE
fix: update podzilla-utils-lib version to v1.1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.github.Podzilla</groupId>
             <artifactId>podzilla-utils-lib</artifactId>
-            <version>v1.1.12</version>
+            <version>v1.1.13</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This pull request includes a version update for a dependency in the `pom.xml` file.

* Updated the `podzilla-utils-lib` dependency from version `v1.1.12` to `v1.1.13` to ensure the project uses the latest features and fixes provided by the library.